### PR TITLE
Fix issue when rendering translated validation messages with a template format

### DIFF
--- a/src/LIN3S/WPSymfonyForm/Controller/AjaxController.php
+++ b/src/LIN3S/WPSymfonyForm/Controller/AjaxController.php
@@ -59,7 +59,7 @@ class AjaxController
     {
         $errors = [];
         foreach ($form->getErrors() as $error) {
-            $errors[] = Translator::instance()->trans($error->getMessage(), [], 'validators');
+            $errors[] = Translator::instance()->trans($error->getMessageTemplate(), $error->getMessageParameters(), 'validators');
         }
         foreach ($form->all() as $child) {
             if (!$child->isValid()) {


### PR DESCRIPTION
- Uses built in error class getMessageTemplate and getMessageParameters to match the translation catalogue correctly
